### PR TITLE
Added TypeScript declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,23 @@
+declare module 'merkletreejs' {
+  interface IOptions {
+    isBitcoinTree: boolean
+  }
+
+  interface IProof {
+    position: 'left' | 'right'
+    data: Buffer
+  }
+
+  export default class MerkleTree {
+    getRoot: () => Buffer
+    getLeaves: () => Buffer[]
+    getLayers: () => Buffer[]
+    getProof: (leaf: Buffer, index?: number) => IProof[]
+    verify: (proof: IProof[], targetNode: Buffer, root: Buffer) => boolean
+    constructor(
+      leaves: Buffer[],
+      hashAlgorithm: (data: any) => Buffer,
+      options?: IOptions
+    )
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.10",
   "description": "Construct Merkle Trees and verify proofs",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "tape test/*.js",
     "docs:md": "node jsdoc.js"


### PR DESCRIPTION
TypeScript developers can how do the following instead of `require` when consuming this package (once it's updated on npm):

```
import MerkleTree from 'merkletreejs'
```

and they will now have types!
