### PR TITLE
adds positional hex proof

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,32 @@ Name | Type | Description |
 
 ___
 
+###  getPositionalHexProof
+
+▸ **getPositionalHexProof**(`leaf`: Buffer, `index?`: number): *(string | number)[][]*
+
+getPositionalHexProof
+
+**`desc`** Returns the proof for a target leaf as hex strings and corresponding position as binary.
+
+**`example`**
+```js
+const proof = tree.getPositionalHexProof(leaves[2])
+```
+
+**Parameters:**
+
+Name | Type | Description |
+------ | ------ | ------ |
+`leaf` | Buffer | Target leaf |
+`index?` | number | - |
+
+**Returns:** *(string | number)[][]*
+
+- Proof array as hex strings with position.
+
+___
+
 ###  getHexRoot
 
 ▸ **getHexRoot**(): *string*

--- a/index.ts
+++ b/index.ts
@@ -426,6 +426,27 @@ export class MerkleTree {
   }
 
   /**
+  * getPositionalHexProof
+  * @desc Returns the proof for a target leaf as hex strings and the position in binary (left == 0).
+  * @param {Buffer} leaf - Target leaf
+  * @param {Number} [index] - Target leaf index in leaves array.
+  * Use if there are leaves containing duplicate data in order to distinguish it.
+  * @return {(string | number)[][]} - Proof array as hex strings. position at index 0
+  * @example
+  * ```js
+  *const proof = tree.getPositionalHexProof(leaves[2])
+  *```
+  */
+  getPositionalHexProof (leaf: Buffer, index?: number): (string | number)[][] {
+    return this.getProof(leaf, index).map(x => {
+      return [
+        x.position === 'left' ? 0 : 1,
+        this.bufferToHex(x.data)
+      ]
+    })
+  }
+
+  /**
    * marshalProof
    * @desc Returns proof array as JSON string.
    * @param {String[]|Object[]} proof - Merkle tree proof array
@@ -691,6 +712,9 @@ export class MerkleTree {
       if (typeof node === 'string') {
         data = this.bufferify(node)
         isLeftNode = true
+      } else if (Array.isArray(node)) {
+        isLeftNode = (node[0] === 0)
+        data = this.bufferify(node[1])
       } else if (node instanceof Object) {
         data = this.bufferify(node.data)
         isLeftNode = (node.position === 'left')

--- a/test/merkletree.test.js
+++ b/test/merkletree.test.js
@@ -88,6 +88,32 @@ test('sha256 with sort pairs option', t => {
   t.equal(tree.getRoot().toString('hex'), root)
 })
 
+test('sha256 verify with positional hex proof and no pairSort', t => {
+  t.plan(1)
+
+  const leaves = ['a', 'b', 'c', 'd', 'e', 'f'].map(x => sha256(x))
+  const tree = new MerkleTree(leaves, sha256, { sortPairs: false })
+  t.true(tree.verify(tree.getPositionalHexProof(leaves[1], 1), leaves[1], tree.getHexRoot()))
+})
+
+test('sha256 verify with non-hex proof and no pairSort', t => {
+  t.plan(1)
+
+  const leaves = ['a', 'b', 'c', 'd', 'e', 'f'].map(x => sha256(x))
+  const tree = new MerkleTree(leaves, sha256, { sortPairs: false })
+
+  t.true(tree.verify(tree.getProof(leaves[1], 1), leaves[1], tree.getHexRoot()))
+})
+
+test('sha256 verify with hex proof and pairSort', t => {
+  t.plan(1)
+
+  const leaves = ['a', 'b', 'c', 'd', 'e', 'f'].map(x => sha256(x))
+  const tree = new MerkleTree(leaves, sha256, { sortPairs: true })
+
+  t.true(tree.verify(tree.getHexProof(leaves[1], 1), leaves[1], tree.getHexRoot()))
+})
+
 test('keccak with sort leaves and sort pairs option', t => {
   t.plan(1)
 


### PR DESCRIPTION
## Motivation:
For my current project, I have to calculate a  merkle root in a zkSNARK program (I'm using [ZoKrates](https://github.com/Zokrates/ZoKrates)). One issue that popped up is the fact that I can't compare hex values in a ZoKrates program in an efficient manner, so I need a positional argument, in order to calculate and verify a pair sorted merkle tree. 
While I could convert the buffer locally, I feel like it might be a worthy addition to this package, especially with zk_rollup technology slowly moving into production systems, where large merkle trees are stored off-chain.

## Usecases/outlook
So, I will be using this for a zk_rollup based system and I feel like it would be nice to have native support in this package, as it will do the heavy lifting in the system, while the zkSNARK program will be used to verify changes and prove correctness on-chain. There are a couple of things that I would still add in the process of my project, for example defining hex proof length (ZoKrates largest hex values are 32 bit) and also multi-proof support. Since I have to make these changes anyway, I would like to spend some extra time for the benefit of an open-source project, at least if it's wanted. 

## Changes:
Changes to the package are quite minimal, and unintrusive, so I don't see how they would be causing any issues. I've added a test as well. 