### PR TITLE
[Tiny] Typo: Updating name of package in example html

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -37,7 +37,7 @@
   </style>
 </head>
 <body>
-  <h1>MerleTree.js example</h1>
+  <h1>MerkleTree.js example</h1>
   <div>
     <details open>
       <summary>Input ▾</summary>


### PR DESCRIPTION
Updating the package name in the example html page. Small thing, but I use this page in a student demo and one of my students noted down the wrong name from the page heading
Thanks for this wonderful package